### PR TITLE
perturbed_translationの設定のbug fix

### DIFF
--- a/Perturbation/perturbation.py
+++ b/Perturbation/perturbation.py
@@ -82,8 +82,8 @@ def perturbation(
                 "do_parallel": True,
                 "sample_cells": False,
                 "perturbation": True,
-                "perturbed_transcription": trans,#{ 'g1': 10.0 },
-                #"perturbed_translation": , # 片方を想定
+                #"perturbed_transcription": trans,#{ 'g1': 10.0 },
+                "perturbed_translation": trans, # 片方を想定
                 "perturbation_input": model_definition[:-4] + "/simulations/", #ここが同じなら初期状態も同じ
 
                 "perturbation_sampling_time": sampling_time,

--- a/Perturbation/perturbation.py
+++ b/Perturbation/perturbation.py
@@ -56,7 +56,7 @@ def perturbation(
                 "do_parallel": False,
                 "sample_cells": False,
                 "perturbation": True,
-                "perturbed_transcription": trans,#{ 'g1': 10.0 },
+                "perturbed_transcription": trans, #{ 'g1': 10.0 },
                 #"perturbed_translation": , # 片方を想定
                 "perturbation_input": model_definition[:-4] + "/simulations/", #ここが同じなら初期状態も同じ
 
@@ -79,7 +79,7 @@ def perturbation(
                 "model_initial_conditions": model_definition + "_ics.txt",
                 "simulation_time": simulation_time,
                 "num_cells": num_cells,
-                "do_parallel": True,
+                "do_parallel": False,
                 "sample_cells": False,
                 "perturbation": True,
                 #"perturbed_transcription": trans,#{ 'g1': 10.0 },


### PR DESCRIPTION
1. perturbed_translationを入力として与えたときでも"perturbed_transcription"が設定されるようになっていたので、直しました。
2. "do_parallel": True の設定だと関数Experiment内の以下の部分のjob.wait()で永遠にwaitし続けてしまったので、"do_parallel": False の設定に直しました。

```python
    if settings['doParallel']:
        with mp.Pool() as pool:
            jobs = []
            for cellid in range(settings['num_cells']):
                cell_args = dict(argdict, seed=cellid, cellid=cellid)
                job = pool.apply_async(simulateAndSample, args=(cell_args,))
                jobs.append(job)
                
            for job in jobs:
                job.wait()
```